### PR TITLE
upgraded Python version to 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5
+FROM python:3.8
 
 RUN apt-get update && apt-get -y install apt-utils supervisor
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 Set up docker for, e.g., Ubuntu, using the stable channel
 =========================================================
 
@@ -15,8 +14,8 @@ Instructions cribbed from: https://docs.docker.com/install/linux/docker-ce/ubunt
        $(lsb_release -cs) \
        stable"
 
-Install docker
-==============
+Install Docker
+--------------
 $ sudo apt-get update
 $ sudo apt-get install docker-ce docker-compose
 
@@ -26,18 +25,18 @@ $ sudo adduser $LOGNAME docker
 $ exec newgrp docker    # or log out, log back in
 
 Edit db.env file
-================
+----------------
 
 $ cp db.env.example db.env
 $ $EDITOR db.env
 
 Set up environment
-==================
+------------------
 
 $ docker-compose up
 
 Test
-====
+----
 
     $ env-vars ()
     {


### PR DESCRIPTION
Python 3.5 is going to be discontinued in September 2020, hence we need to upgrade to the latest version.

https://devguide.python.org/#status-of-python-branches